### PR TITLE
Fix a crash on unavailability of a location provider

### DIFF
--- a/traccar-client/src/main/java/org/traccar/client/PositionProvider.java
+++ b/traccar-client/src/main/java/org/traccar/client/PositionProvider.java
@@ -65,10 +65,18 @@ public class PositionProvider {
 
     public void startUpdates() {
         if (useFine) {
-            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, period, 0, fineLocationListener);
+            try {
+                locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, period, 0, fineLocationListener);
+            } catch (Exception ex) {
+                
+            }
         }
         if (useCoarse) {
-            locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, period, 0, coarseLocationListener);
+            try {
+                locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, period, 0, coarseLocationListener);
+            } catch (Exception ex) {
+
+            }
         }
         handler.postDelayed(updateTask, period);
     }


### PR DESCRIPTION
If a location provider is unavailable (e.g. the user disabled it in the settings menu) than the client will crash because an IllegalArgumentException is not caught. The provider cannot be changed in the settings menu because the client will crash before the user can select another provider.

Maybe a message should be added informing the user about the unavailability of the provider.
