### PR TITLE
Move the startForeground function to the onCreate method

### DIFF
--- a/app/src/main/java/org/traccar/client/TrackingService.java
+++ b/app/src/main/java/org/traccar/client/TrackingService.java
@@ -34,6 +34,7 @@ public class TrackingService extends Service {
 
     private boolean foreground;
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onCreate() {
         Log.i(TAG, "service create");
@@ -43,19 +44,6 @@ public class TrackingService extends Service {
         trackingController.start();
 
         foreground = PreferenceManager.getDefaultSharedPreferences(this).getBoolean(MainActivity.KEY_FOREGROUND, false);
-    }
-
-    @Override
-    public IBinder onBind(Intent intent) {
-        return null;
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void onStart(Intent intent, int startId) {
-        if (intent != null) {
-            AutostartReceiver.completeWakefulIntent(intent);
-        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR && foreground) {
             Intent notificationIntent = new Intent(this, MainActivity.class);
@@ -75,6 +63,20 @@ public class TrackingService extends Service {
 
             startForeground(notificationId, notification);
         }
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onStart(Intent intent, int startId) {
+        if (intent != null) {
+            AutostartReceiver.completeWakefulIntent(intent);
+        }
+
     }
 
     @TargetApi(Build.VERSION_CODES.ECLAIR)


### PR DESCRIPTION
This is a bit cosmetic but this is my first pull request. So I make it easy.
I moved the startForeground function to the onCreate method because it should only be called once at creation. Not each time an intent in received.
 I'll try to find something more useful next time ;-)
