### PR TITLE
Add support for posting locations over HTTPS

### DIFF
--- a/app/src/main/java/org/traccar/client/MainActivity.java
+++ b/app/src/main/java/org/traccar/client/MainActivity.java
@@ -46,6 +46,7 @@ public class MainActivity extends PreferenceActivity implements OnSharedPreferen
     public static final String KEY_DEVICE = "id";
     public static final String KEY_ADDRESS = "address";
     public static final String KEY_PORT = "port";
+    public static final String KEY_SECURE = "secure";
     public static final String KEY_INTERVAL = "interval";
     public static final String KEY_PROVIDER = "provider";
     public static final String KEY_STATUS = "status";
@@ -175,6 +176,7 @@ public class MainActivity extends PreferenceActivity implements OnSharedPreferen
         findPreference(KEY_DEVICE).setEnabled(enabled);
         findPreference(KEY_ADDRESS).setEnabled(enabled);
         findPreference(KEY_PORT).setEnabled(enabled);
+        findPreference(KEY_SECURE).setEnabled(enabled);
         findPreference(KEY_INTERVAL).setEnabled(enabled);
         findPreference(KEY_PROVIDER).setEnabled(enabled);
     }

--- a/app/src/main/java/org/traccar/client/ProtocolFormatter.java
+++ b/app/src/main/java/org/traccar/client/ProtocolFormatter.java
@@ -20,10 +20,10 @@ import android.net.Uri;
 
 public class ProtocolFormatter {
 
-    public static String formatRequest(String address, int port, Position position) {
+    public static String formatRequest(String address, int port, boolean secure, Position position) {
 
         Uri.Builder builder = new Uri.Builder();
-        builder.scheme("http").encodedAuthority(address + ':' + port)
+        builder.scheme(secure?"https":"http").encodedAuthority(address + ':' + port)
                 .appendQueryParameter("id", position.getDeviceId())
                 .appendQueryParameter("timestamp", String.valueOf(position.getTime().getTime() / 1000))
                 .appendQueryParameter("lat", String.valueOf(position.getLatitude()))

--- a/app/src/main/java/org/traccar/client/TrackingController.java
+++ b/app/src/main/java/org/traccar/client/TrackingController.java
@@ -38,6 +38,7 @@ public class TrackingController implements PositionProvider.PositionListener, Ne
 
     private String address;
     private int port;
+    private boolean secure;
 
     private PositionProvider positionProvider;
     private DatabaseHelper databaseHelper;
@@ -74,6 +75,7 @@ public class TrackingController implements PositionProvider.PositionListener, Ne
 
         address = preferences.getString(MainActivity.KEY_ADDRESS, null);
         port = Integer.parseInt(preferences.getString(MainActivity.KEY_PORT, null));
+        secure = preferences.getBoolean(MainActivity.KEY_SECURE, false);
 
         PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, getClass().getName());
@@ -197,7 +199,7 @@ public class TrackingController implements PositionProvider.PositionListener, Ne
     private void send(final Position position) {
         log("send", position);
         lock();
-        String request = ProtocolFormatter.formatRequest(address, port, position);
+        String request = ProtocolFormatter.formatRequest(address, port, secure, position);
         RequestManager.sendRequestAsync(request, new RequestManager.RequestHandler() {
             @Override
             public void onComplete(boolean success) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,11 @@
   <string name="settings_status_on">Stop</string>
   <string name="settings_status_off_summary">Service stopped</string>
   <string name="settings_status_on_summary">Service running</string>
+  <string name="settings_secure_title">Encryption</string>
+  <string name="settings_secure_off">Enable</string>
+  <string name="settings_secure_on">Disable</string>
+  <string name="settings_secure_off_summary">Encryption disabled</string>
+  <string name="settings_secure_on_summary">Encryption enabled</string>
   <string name="settings_provider_title">Location provider</string>
   <string name="settings_provider_summary">Source of location data</string>
   <string name="settings_provider_gps">GPS provider</string>

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -27,6 +27,15 @@
         android:summary="@string/settings_port_summary"
         android:title="@string/settings_port_title" />
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="secure"
+        android:summaryOff="@string/settings_secure_off_summary"
+        android:summaryOn="@string/settings_secure_on_summary"
+        android:switchTextOff="@string/settings_secure_off"
+        android:switchTextOn="@string/settings_secure_on"
+        android:title="@string/settings_secure_title" />
+
     <EditTextPreference
         android:defaultValue="300"
         android:key="interval"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,6 +25,13 @@
         android:summary="@string/settings_port_summary"
         android:title="@string/settings_port_title" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="secure"
+        android:summaryOff="@string/settings_secure_off_summary"
+        android:summaryOn="@string/settings_secure_on_summary"
+        android:title="@string/settings_secure_title" />
+
     <EditTextPreference
         android:defaultValue="300"
         android:key="interval"


### PR DESCRIPTION
For privacy reasons, it is desirable to post over a secure connection when the server supports it. This prevents leaking users' positions to third parties on the network.

A secure connection also protects the device id from eavesdropping and makes it harder for a third party to send fake position updates pretending to be the device.