### PR TITLE
Restore fix auto-start issue on Android O.

### DIFF
--- a/app/src/main/java/org/traccar/client/AutostartReceiver.java
+++ b/app/src/main/java/org/traccar/client/AutostartReceiver.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.support.v4.content.WakefulBroadcastReceiver;
 
 public class AutostartReceiver extends WakefulBroadcastReceiver {
     
@@ -27,7 +26,7 @@ public class AutostartReceiver extends WakefulBroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         if (sharedPreferences.getBoolean(MainFragment.KEY_STATUS, false)) {
-            startWakefulService(context, new Intent(context, TrackingService.class));
+            startWakefulForegroundService(context, new Intent(context, TrackingService.class));
         }
     }
 

--- a/app/src/main/java/org/traccar/client/WakefulBroadcastReceiver.java
+++ b/app/src/main/java/org/traccar/client/WakefulBroadcastReceiver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.client;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.PowerManager;
+import android.support.v4.content.ContextCompat;
+import android.util.SparseArray;
+
+public abstract class WakefulBroadcastReceiver extends BroadcastReceiver {
+    private static final String EXTRA_WAKE_LOCK_ID = "android.support.content.wakelockid";
+    private static final SparseArray<PowerManager.WakeLock> mActiveWakeLocks = new SparseArray<>();
+    private static int mNextId = 1;
+
+    public static void startWakefulForegroundService(Context context, Intent intent) {
+        synchronized (mActiveWakeLocks) {
+            int id = mNextId;
+            mNextId++;
+            if (mNextId <= 0) {
+                mNextId = 1;
+            }
+            intent.putExtra(EXTRA_WAKE_LOCK_ID, id);
+            ContextCompat.startForegroundService(context, intent);
+            PowerManager pm = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
+            PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                    WakefulBroadcastReceiver.class.getSimpleName());
+            wl.setReferenceCounted(false);
+            wl.acquire(60*1000);
+            mActiveWakeLocks.put(id, wl);
+        }
+    }
+
+    public static boolean completeWakefulIntent(Intent intent) {
+        final int id = intent.getIntExtra(EXTRA_WAKE_LOCK_ID, 0);
+        if (id == 0) {
+            return false;
+        }
+        synchronized (mActiveWakeLocks) {
+            PowerManager.WakeLock wl = mActiveWakeLocks.get(id);
+            if (wl != null) {
+                wl.release();
+                mActiveWakeLocks.remove(id);
+                return true;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
As per comment in #303 I realised removing this code was a mistake. I did no realise that it was different to the SDK version of the class. This reverts the removal of the custom `WakefulBroadcastReceiver`. I have also renamed `startWakefulService` to `startWakefulForegroundService` to highlight that it's different to the SDK version.
