### PR TITLE
Show online/offline in connection changed status messages.

### DIFF
--- a/app/src/main/java/org/traccar/client/TrackingController.java
+++ b/app/src/main/java/org/traccar/client/TrackingController.java
@@ -100,7 +100,8 @@ public class TrackingController implements PositionProvider.PositionListener, Ne
 
     @Override
     public void onNetworkUpdate(boolean isOnline) {
-        StatusActivity.addMessage(context.getString(R.string.status_connectivity_change));
+        int message = isOnline ? R.string.status_network_online : R.string.status_network_offline;
+        StatusActivity.addMessage(context.getString(message));
         if (!this.isOnline && isOnline) {
             read();
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,7 +39,8 @@
   <string name="status_send_success">Send successfully</string>
   <string name="status_send_fail">Send failed</string>
   <string name="status_location_update">Location update</string>
-  <string name="status_connectivity_change">Connectivity change</string>
+  <string name="status_network_online">Network online</string>
+  <string name="status_network_offline">Network offline</string>
   <string name="hidden_app_name">Device Settings</string>
   <string name="hidden_alert">The app has been hidden. To open it again please dial 8722227 (TRACCAR).</string>
   <string name="error_msg_invalid_url">Please enter a valid http:// or https:// URL</string>


### PR DESCRIPTION

This change shows if you went offline or online in the status activity on connections change. I find this useful when debugging connectivity issues.

![screenshot_1518435926](https://user-images.githubusercontent.com/352175/36095575-657b21d6-0ffb-11e8-9e64-da6c0679faef.png)